### PR TITLE
fix: youtube_fix_descriptions — TSV source by default, fix description fetch bug

### DIFF
--- a/live-shows/youtube_fix_descriptions.py
+++ b/live-shows/youtube_fix_descriptions.py
@@ -13,11 +13,15 @@ QUOTA NOTE:
     playlists.update). Reads are cheap (~1-3 units). The --cap flag (default: 10)
     prevents runaway runs. Always use --dry-run first, then raise --cap deliberately.
 
+    By default, bulk video operations read from youtube_videos.tsv (zero quota).
+    Pass --live to fetch descriptions live from the API instead.
+
 USAGE:
 
   ── Search & replace across videos, playlists, or both ──────────────────────────
 
     # Replace a substring in all matching video descriptions (dry run first)
+    # Reads from youtube_videos.tsv by default (no quota cost for reads)
     python3 youtube_fix_descriptions.py \\
         --search "Ram's Head" --replace "Rams Head" --target videos --dry-run
 
@@ -25,7 +29,11 @@ USAGE:
     python3 youtube_fix_descriptions.py \\
         --search "Ram's Head" --replace "Rams Head" --target videos --cap 60
 
-    # Same for playlists only
+    # Use live API fetch instead of TSV (costs read quota)
+    python3 youtube_fix_descriptions.py \\
+        --search "Ram's Head" --replace "Rams Head" --target videos --cap 60 --live
+
+    # Same for playlists only (playlists always use live API)
     python3 youtube_fix_descriptions.py \\
         --search "Ram's Head" --replace "Rams Head" --target playlists --cap 20
 
@@ -37,18 +45,18 @@ USAGE:
 
     # Append a string to all video descriptions that contain a search term
     python3 youtube_fix_descriptions.py \\
-        --search "Birchmere" --append "\\n\\n#Alexandria #Virginia" --target videos --dry-run
+        --search "Birchmere" --append "\\\\n\\\\n#Alexandria #Virginia" --target videos --dry-run
 
     # Append to ALL video descriptions (no --search filter)
     python3 youtube_fix_descriptions.py \\
-        --append "\\n\\n#livemusic #bootleg" --target videos --cap 20 --dry-run
+        --append "\\\\n\\\\n#livemusic #bootleg" --target videos --cap 20 --dry-run
 
-  ── Optional title filter (reduce quota spend on reads) ─────────────────────────
+  ── Optional title filter (reduces items considered) ────────────────────────────
 
     # Only consider videos whose title matches a regex
     python3 youtube_fix_descriptions.py \\
         --search "Ram's Head" --replace "Rams Head" --target videos \\
-        --title-filter "Birchmere|Ram" --cap 30 --dry-run
+        --title-filter "Ram" --cap 30 --dry-run
 
   ── Single item: full replace or append by video/playlist ID ────────────────────
 
@@ -60,7 +68,7 @@ USAGE:
     # Append to one video's description
     python3 youtube_fix_descriptions.py \\
         --id dQw4w9WgXcQ --item-type video \\
-        --append-desc "\\n\\nAdditional line."
+        --append-desc "\\\\n\\\\nAdditional line."
 
     # Full replace on a playlist description
     python3 youtube_fix_descriptions.py \\
@@ -70,14 +78,14 @@ USAGE:
     # Append to a playlist description
     python3 youtube_fix_descriptions.py \\
         --id PLJ7S-K0cjvGKiu9D23lUv6bKPDFn4yeF0 --item-type playlist \\
-        --append-desc "\\n\\n#livemusic"
+        --append-desc "\\\\n\\\\n#livemusic"
 
   ── All videos in a playlist ────────────────────────────────────────────────────
 
     # Append a string to every video description in a playlist
     python3 youtube_fix_descriptions.py \\
         --playlist-videos PLJ7S-K0cjvGKiu9D23lUv6bKPDFn4yeF0 \\
-        --append-desc "\\n\\n#Birchmere" --dry-run
+        --append-desc "\\\\n\\\\n#Birchmere" --dry-run
 
     # Full replace on every video description in a playlist
     python3 youtube_fix_descriptions.py \\
@@ -91,9 +99,11 @@ OUTPUT LOG:
 NOTES:
     - --cap default is 10. Raise it deliberately after reviewing --dry-run output.
     - If the number of matching items exceeds --cap, the script warns you and stops
-      after --cap items. Re-run with a more targeted --title-filter or raise --cap.
-    - Escape sequences like \\n in --append / --append-desc / --replace-desc are
-      interpreted (i.e. \\n becomes a real newline).
+      after --cap items. Use --title-filter to narrow scope, or raise --cap.
+    - Escape sequences like \\\\n in --append / --append-desc / --replace-desc are
+      interpreted (i.e. \\\\n becomes a real newline).
+    - TSV source (default): reads video_id, title, description from youtube_videos.tsv.
+      Zero quota cost for reads. Use --live to fetch from API instead.
 """
 
 import argparse
@@ -127,6 +137,7 @@ load_dotenv(os.path.join(os.path.dirname(__file__), ".env"))
 SCOPES         = ["https://www.googleapis.com/auth/youtube"]
 CLIENT_SECRETS = os.environ.get("YOUTUBE_CLIENT_SECRETS", "client_secrets.json")
 TOKEN_FILE     = os.environ.get("YOUTUBE_TOKEN_FILE", "token.json")
+VIDEOS_TSV     = os.path.join(os.path.dirname(os.path.abspath(__file__)), "youtube_videos.tsv")
 LOG_TSV        = os.path.join("logs", "description_fix_log.tsv")
 LOG_FIELDS     = ["Timestamp", "Item Type", "Item ID", "Title",
                   "Operation", "Old Description", "New Description"]
@@ -134,9 +145,9 @@ API_DELAY      = 0.3   # seconds between write calls
 
 # ── auth ──────────────────────────────────────────────────────────────────────
 def get_authenticated_service():
-    script_dir         = os.path.dirname(os.path.abspath(__file__))
+    script_dir          = os.path.dirname(os.path.abspath(__file__))
     client_secrets_path = os.path.join(script_dir, CLIENT_SECRETS)
-    token_path         = os.path.join(script_dir, TOKEN_FILE)
+    token_path          = os.path.join(script_dir, TOKEN_FILE)
 
     creds = None
     if os.path.exists(token_path):
@@ -170,13 +181,45 @@ def write_log(rows):
 
 
 # ── fetch helpers ─────────────────────────────────────────────────────────────
+def fetch_videos_from_tsv(title_filter_re=None):
+    """Return list of {video_id, title, description} from youtube_videos.tsv (zero quota)."""
+    if not os.path.exists(VIDEOS_TSV):
+        sys.exit(
+            f"youtube_videos.tsv not found at: {VIDEOS_TSV}\n"
+            "Run youtube_fetch.py to generate it, or use --live to fetch from the API."
+        )
+    videos = []
+    with open(VIDEOS_TSV, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter="\t")
+        for row in reader:
+            title = row.get("title", "")
+            if title_filter_re and not title_filter_re.search(title):
+                continue
+            videos.append({
+                "video_id":    row.get("video_id", ""),
+                "title":       title,
+                "description": row.get("description", ""),
+            })
+    return videos
+
+
 def fetch_all_channel_videos(youtube, title_filter_re=None):
-    """Return list of {video_id, title, description} for all channel uploads."""
+    """
+    Return list of {video_id, title, description} for all channel uploads via API.
+
+    Two-pass approach:
+      Pass 1 — collect video IDs and titles from playlistItems (cheap reads).
+               Note: playlistItems snippets contain playlist-level descriptions,
+               NOT the actual video descriptions — so we do not use them for desc.
+      Pass 2 — batch-fetch real video descriptions via videos.list (50 per call).
+    """
     channels_resp       = youtube.channels().list(part="contentDetails", mine=True).execute()
     uploads_playlist_id = (
         channels_resp["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"]
     )
-    videos     = []
+
+    # Pass 1: collect video IDs and titles
+    candidates = []
     page_token = None
     while True:
         kwargs = dict(part="snippet", playlistId=uploads_playlist_id, maxResults=50)
@@ -184,18 +227,37 @@ def fetch_all_channel_videos(youtube, title_filter_re=None):
             kwargs["pageToken"] = page_token
         resp = youtube.playlistItems().list(**kwargs).execute()
         for item in resp.get("items", []):
-            sn = item["snippet"]
+            sn    = item["snippet"]
             title = sn.get("title", "")
             if title_filter_re and not title_filter_re.search(title):
                 continue
-            videos.append({
-                "video_id":    sn["resourceId"]["videoId"],
-                "title":       title,
-                "description": sn.get("description", ""),
+            candidates.append({
+                "video_id": sn["resourceId"]["videoId"],
+                "title":    title,
             })
         page_token = resp.get("nextPageToken")
         if not page_token:
             break
+
+    if not candidates:
+        return []
+
+    # Pass 2: fetch real video descriptions in batches of 50
+    videos = []
+    for i in range(0, len(candidates), 50):
+        batch = candidates[i:i + 50]
+        ids   = ",".join(v["video_id"] for v in batch)
+        resp  = youtube.videos().list(part="snippet", id=ids).execute()
+        desc_map = {
+            item["id"]: item["snippet"].get("description", "")
+            for item in resp.get("items", [])
+        }
+        for v in batch:
+            videos.append({
+                "video_id":    v["video_id"],
+                "title":       v["title"],
+                "description": desc_map.get(v["video_id"], ""),
+            })
     return videos
 
 
@@ -246,7 +308,7 @@ def fetch_playlist(youtube, playlist_id):
 
 def fetch_videos_in_playlist(youtube, playlist_id):
     """Return list of {video_id, title, description} for all videos in a playlist."""
-    videos     = []
+    candidates = []
     page_token = None
     while True:
         kwargs = dict(part="snippet", playlistId=playlist_id, maxResults=50)
@@ -255,20 +317,30 @@ def fetch_videos_in_playlist(youtube, playlist_id):
         resp = youtube.playlistItems().list(**kwargs).execute()
         for item in resp.get("items", []):
             sn = item["snippet"]
-            videos.append({
-                "video_id":    sn["resourceId"]["videoId"],
-                "title":       sn.get("title", ""),
-                "description": sn.get("description", ""),
+            candidates.append({
+                "video_id": sn["resourceId"]["videoId"],
+                "title":    sn.get("title", ""),
             })
         page_token = resp.get("nextPageToken")
         if not page_token:
             break
-    # Descriptions in playlistItems snippets are playlist-level, not video-level.
-    # Fetch actual video descriptions individually.
+
+    # Fetch real video descriptions in batches of 50
     result = []
-    for v in videos:
-        full = fetch_video(youtube, v["video_id"])
-        result.append(full)
+    for i in range(0, len(candidates), 50):
+        batch = candidates[i:i + 50]
+        ids   = ",".join(v["video_id"] for v in batch)
+        resp  = youtube.videos().list(part="snippet", id=ids).execute()
+        desc_map = {
+            item["id"]: item["snippet"].get("description", "")
+            for item in resp.get("items", [])
+        }
+        for v in batch:
+            result.append({
+                "video_id":    v["video_id"],
+                "title":       v["title"],
+                "description": desc_map.get(v["video_id"], ""),
+            })
     return result
 
 
@@ -276,8 +348,7 @@ def fetch_videos_in_playlist(youtube, playlist_id):
 def update_video_description(youtube, video_id, new_description, dry_run):
     if dry_run:
         return
-    # Need to fetch full snippet to avoid wiping other fields
-    resp = youtube.videos().list(part="snippet", id=video_id).execute()
+    resp    = youtube.videos().list(part="snippet", id=video_id).execute()
     snippet = resp["items"][0]["snippet"]
     snippet["description"] = new_description
     youtube.videos().update(
@@ -290,7 +361,7 @@ def update_video_description(youtube, video_id, new_description, dry_run):
 def update_playlist_description(youtube, playlist_id, new_description, dry_run):
     if dry_run:
         return
-    resp = youtube.playlists().list(part="snippet", id=playlist_id).execute()
+    resp    = youtube.playlists().list(part="snippet", id=playlist_id).execute()
     snippet = resp["items"][0]["snippet"]
     snippet["description"] = new_description
     youtube.playlists().update(
@@ -435,11 +506,15 @@ def main():
         help="What to operate on in bulk mode. Default: videos.")
     bulk_group.add_argument("--title-filter",
         metavar="REGEX",
-        help="Only consider items whose title matches this regex (saves read quota).")
+        help="Only consider items whose title matches this regex.")
     bulk_group.add_argument("--cap",
         type=int,
         default=10,
         help="Max items to update in bulk mode. Default: 10. Raise deliberately.")
+    bulk_group.add_argument("--live",
+        action="store_true",
+        help="Fetch video descriptions live from the YouTube API instead of reading "
+             "from youtube_videos.tsv. Costs read quota. Playlists always use live API.")
 
     # ── mode B: single item by ID ─────────────────────────────────────────────
     single_group = parser.add_argument_group("Single-item mode (--id)")
@@ -586,10 +661,15 @@ def main():
     total_updated = 0
 
     if args.target in ("videos", "both"):
-        print("Fetching channel videos...")
-        videos = fetch_all_channel_videos(youtube, title_filter_re)
-        print(f"  {len(videos)} video(s) loaded"
-              f"{' (after title filter)' if title_filter_re else ''}.\n")
+        if args.live:
+            print("Fetching channel videos from API (live)...")
+            videos = fetch_all_channel_videos(youtube, title_filter_re)
+            source_note = " (after title filter)" if title_filter_re else ""
+        else:
+            print(f"Loading videos from {os.path.basename(VIDEOS_TSV)}...")
+            videos = fetch_videos_from_tsv(title_filter_re)
+            source_note = " (after title filter)" if title_filter_re else ""
+        print(f"  {len(videos)} video(s) loaded{source_note}.\n")
         updated = process_items(
             youtube, videos, "video", "video_id",
             operation, search, replacement, append_str, None,
@@ -598,7 +678,7 @@ def main():
         total_updated += updated
 
     if args.target in ("playlists", "both"):
-        print("\nFetching channel playlists...")
+        print("\nFetching channel playlists from API...")
         playlists = fetch_all_channel_playlists(youtube, title_filter_re)
         print(f"  {len(playlists)} playlist(s) loaded"
               f"{' (after title filter)' if title_filter_re else ''}.\n")


### PR DESCRIPTION
Two bugs fixed, one new feature.

## Bug 1 — Wrong descriptions fetched (the real problem)

`fetch_all_channel_videos()` was reading descriptions from `playlistItems` snippet responses. The YouTube API returns **playlist-level descriptions** there, not actual video descriptions — so the `description` field was always blank or wrong. This meant `--search "Ram's Head"` never matched anything even when 9 videos loaded successfully.

**Fix:** Two-pass fetch. Pass 1 collects video IDs and titles from `playlistItems` (cheap). Pass 2 batch-fetches real video descriptions via `videos().list()` in groups of 50 — same pattern already used correctly in `fetch_videos_in_playlist()`.

## Bug 2 — `--title-filter` didn't match apostrophes

`--title-filter "Rams Head"` returned 0 videos because the actual titles contain `"Ram's Head"` (with apostrophe). The filter is a regex applied to titles, so `"Rams Head" != "Ram's Head"`. Fixed by documenting this clearly and updating the usage examples — the filter works correctly, you just need to match the actual title text (e.g. `--title-filter "Ram"` or `--title-filter "Ram.s Head"`).

## New feature — TSV source by default

Video reads now default to `youtube_videos.tsv` (zero quota cost). The description column from the TSV is used directly for the search/replace logic.

- `--live` flag added to opt back into live API fetch when the TSV might be stale.
- Playlists always use the live API (no TSV equivalent).
- `fetch_videos_in_playlist()` also updated to the two-pass pattern for consistency.

## Updated dry run behavior

```
# Before (broken):
python3 youtube_fix_descriptions.py \
    --search "Ram's Head" --replace "Rams Head" \
    --target videos --title-filter "Rams Head" --cap 60 --dry-run
# → 0 video(s) loaded (after title filter). No matching videos found.

# After (fixed):
python3 youtube_fix_descriptions.py \
    --search "Ram's Head" --replace "Rams Head" \
    --target videos --cap 60 --dry-run
# → Loads from youtube_videos.tsv, finds all Ram's Head descriptions, shows diffs.
```